### PR TITLE
Add support for setting a background color

### DIFF
--- a/Examples/VolVisualizer.cpp
+++ b/Examples/VolVisualizer.cpp
@@ -104,6 +104,7 @@ int main(int argc, char **argv) {
   viewer.addGeometry("Mesh", mesh);
 
   viewer.showGrid = true;
+  viewer.backgroundColor = (Colors::Magenta() + Colors::Cyan()) / 2.0;
 
   Light light;
   light.ambientFactor = 1.0f;

--- a/Source/Shaders/ambientPass.frag
+++ b/Source/Shaders/ambientPass.frag
@@ -5,11 +5,15 @@ in vec2 texcoord;
 
 uniform sampler2D tex;
 uniform vec3 lightColor;
+uniform sampler2D indexTex;
 
 layout(location = 0) out vec4 color;
 
 void main() {
-  color = vec4(texture(tex, texcoord).rgb * lightColor, 1.0);
+  vec4 idx = texture(indexTex, texcoord).rgba;
+  float isForeGround = max(1.0, idx.r + idx.g + idx.b + idx.a);
+  vec3 albedo = texture(tex, texcoord).rgb;
+  color = vec4(albedo * (1.0 - isForeGround + lightColor), 1.0);
 }
 
 )"

--- a/Source/Shaders/diffuseLighting.frag
+++ b/Source/Shaders/diffuseLighting.frag
@@ -6,6 +6,7 @@ layout(location = 0) in vec2 texcoord;
 
 uniform sampler2D normalAndSpecularTex;
 uniform sampler2D albedoTex;
+uniform sampler2D indexTex;
 
 layout(location = 0) out vec4 color;
 
@@ -17,15 +18,17 @@ void main() {
   vec2 normalUV = texture(normalAndSpecularTex, texcoord).xy;
   vec3 normal = vec3(normalUV, sqrt(1.0 - dot(normalUV, normalUV)));
   vec3 albedo = texture(albedoTex, texcoord).rgb;
+  vec4 idx = texture(indexTex, texcoord).rgba;
+  float isForeGround = max(1.0, idx.r + idx.g + idx.b + idx.a);
 
   // compute light direction. Since only directional lights are supported,
   // the direction is equal to the normalized light position
   vec3 lightDirection = normalize(lightPosition);
 
   float lightDotNormal = dot(lightDirection, normal);
-  vec3 diffuseColor = lightColor * max(0.0, lightDotNormal);
+  vec3 diffuseColor = lightColor * min(isForeGround, max(0.0, lightDotNormal));
 
-  color.rgb = albedo * diffuseColor;
+  color.rgb = albedo * (1.0 - isForeGround + diffuseColor);
 }
 
 )"

--- a/Source/Shaders/specularLighting.frag
+++ b/Source/Shaders/specularLighting.frag
@@ -6,6 +6,7 @@ layout(location = 0) in vec2 texcoord;
 
 uniform sampler2D normalAndSpecularTex;
 uniform sampler2D albedoTex;
+uniform sampler2D indexTex;
 
 layout(location = 0) out vec4 color;
 
@@ -16,6 +17,8 @@ void main() {
   // Read values from textures
   vec4 normalAndSpecular = texture(normalAndSpecularTex, texcoord);
   vec3 albedo = texture(albedoTex, texcoord).rgb;
+  vec4 idx = texture(indexTex, texcoord).rgba;
+  float isForeGround = max(1.0, idx.r + idx.g + idx.b + idx.a);
 
   vec2 normalUV = normalAndSpecular.xy;
   vec3 specular = vec3(normalAndSpecular.z);
@@ -32,9 +35,9 @@ void main() {
   // reflectedRatDirection.z
   vec3 specularColor =
      lightColor * specular *
-       pow(max(0.0, reflectedRayDirection.z), shininess);
+       min(isForeGround, pow(max(0.0, reflectedRayDirection.z), shininess));
 
-  color.rgb = albedo * specularColor;
+  color.rgb = albedo * (1.0 - isForeGround + specularColor);
 }
 
 )"

--- a/include/VolViz/src/Visualizer.h
+++ b/include/VolViz/src/Visualizer.h
@@ -71,6 +71,7 @@ public:
   std::atomic<bool> showGrid{true};
   std::atomic<bool> showVolumeBoundingBox{true};
   AtomicProperty<Length> scale{1 * milli * meter};
+  AtomicProperty<Color> backgroundColor{Colors::Black()};
 
   /// The camera
   Camera camera;


### PR DESCRIPTION
Because of the deferred lighting technique used, several shaders must be
edited. Since the lighting fragment shaders cannot distinguish between
an object pixel and a backgroud pixel, the selection is now used to
distinguish between background (index = 0) and foreground (index > 0).
In case of background the lighting equation is ignored.